### PR TITLE
Removing Parallels Virtualization SDK dependency from PDfM 19.0.0

### DIFF
--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -63,14 +63,14 @@ func (d *Parallels9Driver) sendJsonScancodes(vmName string, inputScanCodes []str
 			scancodeData = append(scancodeData, ScanCodes{Scancode: key1 - 128, Event: "release", Delay: delay})
 		}
 	}
-	jsonFormat, err := json.MarshalIndent(scancodeData, "", "\t")
+	jsonFormat, err := json.Marshal(scancodeData)
 	if err != nil {
 		log.Println(err)
 		return err
 	}
 
 	log.Printf("complete scancode data in JSON format %s", jsonFormat)
-	err = d.Prlctl("send-key-event", vmName, "-j", fmt.Sprintf("%s", jsonFormat))
+	err = d.Prlctl("send-key-event", vmName, "-j", string(jsonFormat))
 
 	if err != nil {
 		log.Println(err)
@@ -343,6 +343,8 @@ func (d *Parallels9Driver) Version() (string, error) {
 
 // SendKeyScanCodes sends the specified scancodes as key events to the VM.
 // It is performed using "Prltype" script (refer to "prltype.go").
+// scancodes are sent by using python SDK if version is  < 19.0.0
+// scancodes are sent by using prlctl CMD if version is  >= 19.0.0
 func (d *Parallels9Driver) SendKeyScanCodes(vmName string, codes ...string) error {
 	var stdout, stderr bytes.Buffer
 	var err error

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -58,7 +58,7 @@ type ScanCodes struct {
 }
 
 // sending scancodes to VM via prlctl CMD
-func sendJsonScancodes(vmName string, inputScanCodes []string) error {
+func (d *Parallels9Driver) sendJsonScancodes(vmName string, inputScanCodes []string) error {
 	scancodeData := []ScanCodes{}
 
 	log.Println("scancodes received for JSON encoding ", inputScanCodes)
@@ -96,33 +96,13 @@ func sendJsonScancodes(vmName string, inputScanCodes []string) error {
 		return err
 	}
 
-	log.Printf("complete scancode data in JSON format %s", string(jsonFormat))
-
-	var str string = "prlctl send-key-event " + vmName + " " + " -j " + string(jsonFormat)
-	log.Println("prlctl command to send scancodes ", str)
-
-	/* Enable this when prlctl send-key-evnt cmd is available
-
-	cmd := exec.Command("prlctl send-key-event", vmName, "-j", string(jsonFormat))
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err = cmd.Run()
-	os.Remove(f.Name())
-
-	stdoutString := strings.TrimSpace(stdout.String())
-	stderrString := strings.TrimSpace(stderr.String())
-
-	if _, ok := err.(*exec.ExitError); ok {
-		err = fmt.Errorf("prlctl error: %s", stderrString)
-	}
-
-	log.Printf("stdout: %s", stdoutString)
-	log.Printf("stderr: %s", stderrString)
+	log.Printf("complete scancode data in JSON format %s", jsonFormat)
+	err = d.Prlctl("send-key-event", vmName, "-j", fmt.Sprintf("%s", jsonFormat))
 
 	if err != nil {
 		log.Println(err)
 		return err
-	} */
+	}
 	return nil
 }
 
@@ -433,13 +413,8 @@ func (d *Parallels9Driver) SendKeyScanCodes(vmName string, codes ...string) erro
 
 		log.Printf("stdout: %s", stdoutString)
 		log.Printf("stderr: %s", stderrString)
-		// TO DO Remove this
-		log.Printf("------START--------")
-		sendJsonScancodes(vmName, codes)
-		log.Printf("------END-----------")
-		// ---
 	} else {
-		err = sendJsonScancodes(vmName, codes)
+		err = d.sendJsonScancodes(vmName, codes)
 	}
 	return err
 }

--- a/builder/parallels/common/driver_9.go
+++ b/builder/parallels/common/driver_9.go
@@ -373,7 +373,7 @@ func (d *Parallels9Driver) SendKeyScanCodes(vmName string, codes ...string) erro
 	prlctlCurrVersion, _ := version.NewVersion(prlctlCurrVersionStr)
 	v2, _ := version.NewVersion("19.0.0")
 
-	if verErr != nil || prlctlCurrVersion.LessThan(v2) {
+	if verErr != nil && prlctlCurrVersion.LessThan(v2) {
 
 		f, err := tmp.File("prltype")
 		if err != nil {


### PR DESCRIPTION
With these changes from PDfM 19.0.0 no need to install parallels Python SDK

### Changes
* Sending scan codes using prlctl send-key-event command
* Initializing the `PYTHONPATH` env variable to fix #36 
* Introduced a check for python sdk only if PDfM is less than 19.0.0



Closes #36


