### PR TITLE
Update makefile generate

### DIFF
--- a/.github/workflows/ensure-docs-compiled.yaml
+++ b/.github/workflows/ensure-docs-compiled.yaml
@@ -9,14 +9,14 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v4
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
 

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -2,7 +2,7 @@
 # https://github.com/hashicorp/integration-template#metadata-configuration
 integration {
   name = "Parallels"
-  description = "TODO"
+  description = "The Parallels plugin can be used with HashiCorp Packer to create custom images on Parallels."
   identifier = "packer/Parallels/parallels"
   component {
     type = "builder"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,10 +20,6 @@ test:
 install-packer-sdc: ## Install packer sofware development command
 	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
-ci-release-docs: install-packer-sdc
-	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst docs/
-	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
-
 plugin-check: install-packer-sdc build
 	@packer-sdc plugin-check ${BINARY}
 
@@ -32,11 +28,8 @@ testacc: dev
 
 generate: install-packer-sdc
 	@go generate ./...
-	packer-sdc renderdocs -src ./docs -dst ./.docs -partials ./docs-partials
-	# checkout the .docs folder for a preview of the docs
-
-build-docs: install-packer-sdc
 	@if [ -d ".docs" ]; then rm -r ".docs"; fi
-	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
+	packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
 	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "Parallels"
 	@rm -r ".docs"
+	# checkout the .docs folder for a preview of the docs


### PR DESCRIPTION
As a follow-up to #94, this PR updates the Makefile to remove `build-docs` and `ci-release-docs` since they are supplanted by `generate` nowadays.

Also, we add a description for the plugin in the metadata file since it's what's shown to users when browsing our docs.