### PR TITLE
Update Packer plugin integration documentation

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -43,23 +43,23 @@ The plugin comes with multiple builders able to create Parallels machines,
 depending on the strategy you want to use to build the image. Packer supports
 the following Parallels builders:
 
-- [parallels-iso](/packer/integrations/parallels/latest/components/builder/iso) - Starts from an ISO
+- [parallels-iso](/packer/integrations/Parallels/parallels/latest/components/builder/iso) - Starts from an ISO
   file, creates a brand new Parallels VM, installs an OS, provisions software
   within the OS, then exports that machine to create an image. This is best
   for people who want to start from scratch.
 
-- [parallels-pvm](/packer/integrations/parallels/latest/components/builder/pvm) - This builder imports
+- [parallels-pvm](/packer/integrations/Parallels/parallels/latest/components/builder/pvm) - This builder imports
   an existing PVM file, runs provisioners on top of that VM, and exports that
   machine to create an image. This is best if you have an existing Parallels
   VM export you want to use as the source. As an additional benefit, you can
   feed the artifact of this builder back into itself to iterate on a machine.
 
-- [parallels-ipsw](/packer/integrations/parallels/latest/components/builder/ipsw) - Starts from an IPSW
+- [parallels-ipsw](/packer/integrations/Parallels/parallels/latest/components/builder/ipsw) - Starts from an IPSW
   file, creates a brand new Parallels Mac OS VM, installs an OS, provisions software
   within the OS, then exports that machine to create an image. This is best
   for people who want to start from scratch.
 
-- [parallels-macvm](/packer/integrations/parallels/latest/components/builder/macvm) - This builder imports
+- [parallels-macvm](/packer/integrations/Parallels/parallels/latest/components/builder/macvm) - This builder imports
   an existing Mac VM file, runs provisioners on top of that VM, and exports that
   machine to create an image. This is best if you have an existing Parallels
   Mac VM export you want to use as the source. As an additional benefit, you can

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -14,4 +14,14 @@ integration {
     name = "Parallels ISO"
     slug = "iso"
   }
+  component {
+    type = "builder"
+    name = "Parallels IPSW"
+    slug = "ipsw"
+  }
+  component {
+    type = "builder"
+    name = "Parallels MACVM"
+    slug = "macvm"
+  }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,23 +43,23 @@ The plugin comes with multiple builders able to create Parallels machines,
 depending on the strategy you want to use to build the image. Packer supports
 the following Parallels builders:
 
-- [parallels-iso](/packer/integrations/parallels/latest/components/builder/iso) - Starts from an ISO
+- [parallels-iso](/packer/integrations/Parallels/parallels/latest/components/builder/iso) - Starts from an ISO
   file, creates a brand new Parallels VM, installs an OS, provisions software
   within the OS, then exports that machine to create an image. This is best
   for people who want to start from scratch.
 
-- [parallels-pvm](/packer/integrations/parallels/latest/components/builder/pvm) - This builder imports
+- [parallels-pvm](/packer/integrations/Parallels/parallels/latest/components/builder/pvm) - This builder imports
   an existing PVM file, runs provisioners on top of that VM, and exports that
   machine to create an image. This is best if you have an existing Parallels
   VM export you want to use as the source. As an additional benefit, you can
   feed the artifact of this builder back into itself to iterate on a machine.
 
-- [parallels-ipsw](/packer/integrations/parallels/latest/components/builder/ipsw) - Starts from an IPSW
+- [parallels-ipsw](/packer/integrations/Parallels/parallels/latest/components/builder/ipsw) - Starts from an IPSW
   file, creates a brand new Parallels Mac OS VM, installs an OS, provisions software
   within the OS, then exports that machine to create an image. This is best
   for people who want to start from scratch.
 
-- [parallels-macvm](/packer/integrations/parallels/latest/components/builder/macvm) - This builder imports
+- [parallels-macvm](/packer/integrations/Parallels/parallels/latest/components/builder/macvm) - This builder imports
   an existing Mac VM file, runs provisioners on top of that VM, and exports that
   machine to create an image. This is best if you have an existing Parallels
   Mac VM export you want to use as the source. As an additional benefit, you can


### PR DESCRIPTION
This change updates the links to the plugin components on the main integration [index page](https://developer.hashicorp.com/packer/integrations/cirruslabs/tart), with the correct URL structure. Integration links now take the following URL format
 `/packer/integrations/org-name/plugin-name/latest/components/type/name`. 

This change also adds the missing Parallels components to the integration sidebar. 

After merging please trigger a manual notify integration release job with the latest plugin version (1.1.5) to refresh the integration portal. Otherwise, the links will remain broken until the next official plugin release. 

#### Example
<img width="936" alt="image" src="https://github.com/cirruslabs/packer-plugin-tart/assets/1749304/9eae3c76-c503-4b1d-aa0e-1b411d7f3397">
