### PR TITLE
`HostInterfaces` by default also try en10 to en20

### DIFF
--- a/.web-docs/components/builder/ipsw/README.md
+++ b/.web-docs/components/builder/ipsw/README.md
@@ -205,6 +205,7 @@ In HCL2:
   host should be searched for a IP address. The first IP address found on one
   of these will be used as `{{ .HTTPIP }}` in the `boot_command`. Defaults to
   \["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+  "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
   "ppp0", "ppp1", "ppp2"\].
 
 - `memory` (number) - The amount of memory to use for building the VM in

--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -256,6 +256,7 @@ In HCL2:
   host should be searched for a IP address. The first IP address found on one
   of these will be used as `{{ .HTTPIP }}` in the `boot_command`. Defaults to
   \["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+  "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
   "ppp0", "ppp1", "ppp2"\].
 
 - `memory` (number) - The amount of memory to use for building the VM in

--- a/builder/parallels/common/host_ip_ifconfig.go
+++ b/builder/parallels/common/host_ip_ifconfig.go
@@ -55,5 +55,10 @@ func (f *IfconfigIPFinder) HostIP() (string, error) {
 			}
 		}
 	}
-	return "", errors.New("IP not found in ifconfig output, check the host_interfaces config to ensure your device is listed")
+
+	devices_checked_list := ""
+	for _, device := range f.Devices {
+		devices_checked_list += device + " "
+	}
+	return "", errors.New("IP not found in ifconfig output, check the host_interfaces config to ensure your device is listed. Devices checked: " + devices_checked_list)
 }

--- a/builder/parallels/common/host_ip_ifconfig.go
+++ b/builder/parallels/common/host_ip_ifconfig.go
@@ -55,5 +55,5 @@ func (f *IfconfigIPFinder) HostIP() (string, error) {
 			}
 		}
 	}
-	return "", errors.New("IP not found in ifconfig output")
+	return "", errors.New("IP not found in ifconfig output, check the host_interfaces config to ensure your device is listed")
 }

--- a/builder/parallels/ipsw/builder.go
+++ b/builder/parallels/ipsw/builder.go
@@ -51,6 +51,7 @@ type Config struct {
 	// host should be searched for a IP address. The first IP address found on one
 	// of these will be used as `{{ .HTTPIP }}` in the boot_command. Defaults to
 	// ["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+	// "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
 	// "ppp0", "ppp1", "ppp2"].
 	HostInterfaces []string `mapstructure:"host_interfaces" required:"false"`
 	// This is the name of the PVM directory for the new
@@ -106,7 +107,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if len(b.config.HostInterfaces) == 0 {
 		b.config.HostInterfaces = []string{"en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7",
-			"en8", "en9", "ppp0", "ppp1", "ppp2"}
+			"en8", "en9", "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20", "ppp0", "ppp1", "ppp2"}
 	}
 
 	if b.config.VMName == "" {

--- a/builder/parallels/iso/builder.go
+++ b/builder/parallels/iso/builder.go
@@ -71,6 +71,7 @@ type Config struct {
 	// host should be searched for a IP address. The first IP address found on one
 	// of these will be used as `{{ .HTTPIP }}` in the boot_command. Defaults to
 	// ["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+	// "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
 	// "ppp0", "ppp1", "ppp2"].
 	HostInterfaces []string `mapstructure:"host_interfaces" required:"false"`
 	// Virtual disk image is compacted at the end of
@@ -146,7 +147,8 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if len(b.config.HostInterfaces) == 0 {
 		b.config.HostInterfaces = []string{"en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7",
-			"en8", "en9", "ppp0", "ppp1", "ppp2"}
+			"en8", "en9", "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
+			"ppp0", "ppp1", "ppp2"}
 	}
 
 	if b.config.VMName == "" {

--- a/docs-partials/builder/parallels/ipsw/Config-not-required.mdx
+++ b/docs-partials/builder/parallels/ipsw/Config-not-required.mdx
@@ -7,6 +7,7 @@
   host should be searched for a IP address. The first IP address found on one
   of these will be used as `{{ .HTTPIP }}` in the boot_command. Defaults to
   ["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+  "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
   "ppp0", "ppp1", "ppp2"].
 
 - `vm_name` (string) - This is the name of the PVM directory for the new

--- a/docs-partials/builder/parallels/iso/Config-not-required.mdx
+++ b/docs-partials/builder/parallels/iso/Config-not-required.mdx
@@ -26,6 +26,7 @@
   host should be searched for a IP address. The first IP address found on one
   of these will be used as `{{ .HTTPIP }}` in the boot_command. Defaults to
   ["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+  "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
   "ppp0", "ppp1", "ppp2"].
 
 - `skip_compaction` (bool) - Virtual disk image is compacted at the end of

--- a/docs/builders/ipsw.mdx
+++ b/docs/builders/ipsw.mdx
@@ -178,6 +178,7 @@ In HCL2:
   host should be searched for a IP address. The first IP address found on one
   of these will be used as `{{ .HTTPIP }}` in the `boot_command`. Defaults to
   \["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+  "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
   "ppp0", "ppp1", "ppp2"\].
 
 - `memory` (number) - The amount of memory to use for building the VM in

--- a/docs/builders/iso.mdx
+++ b/docs/builders/iso.mdx
@@ -144,6 +144,7 @@ can also be supplied to override the typical auto-generated key:
   host should be searched for a IP address. The first IP address found on one
   of these will be used as `{{ .HTTPIP }}` in the `boot_command`. Defaults to
   \["en0", "en1", "en2", "en3", "en4", "en5", "en6", "en7", "en8", "en9",
+  "en10", "en11", "en12", "en13", "en14", "en15", "en16", "en17", "en18", "en19", "en20",
   "ppp0", "ppp1", "ppp2"\].
 
 - `memory` (number) - The amount of memory to use for building the VM in


### PR DESCRIPTION
Can we extend the list of default interfaces to find the `host ip` to look thru `en20`? I personally am using `en13` and `en16`. Of course, there is no way to extend this to everyone's satisfaction. 

Also, I made a quick change to the error message to indicate that configuring `host_interfaces` may be where one can fix the `host ip` not found error. Just added the list of devices checked too. This would've saved me at least 5 minutes of time (as a n00b) to fix this the first time I encountered it.