### PR TITLE
Fix issue with parallels-ipsw not running custom prlctl commands

### DIFF
--- a/builder/parallels/ipsw/builder.go
+++ b/builder/parallels/ipsw/builder.go
@@ -149,6 +149,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
 		new(stepCreateVM),
+		&parallelscommon.StepPrlctl{
+			Commands: b.config.Prlctl,
+			Ctx:      b.config.ctx,
+		},
 		&parallelscommon.StepRun{},
 		&parallelscommon.StepTypeBootCommand{
 			BootWait:       b.config.BootWait,


### PR DESCRIPTION
Added a call from parallels-ipsw builder to parallelscommon.StepPrlctl so custom prlctl commands are executed after vm creation.

Closes #109 

