### PR TITLE
Add support for configuring disk size in parallels-ipsw builder

### DIFF
--- a/.web-docs/components/builder/ipsw/README.md
+++ b/.web-docs/components/builder/ipsw/README.md
@@ -31,6 +31,7 @@ source "parallels-ipsw" "macvm_automated" {
   vm_name              = "macOS"
   cpus                 = "4"
   memory               = "8192"
+  disk_size            = "50000"
 }
 
 build {
@@ -200,6 +201,9 @@ In HCL2:
 
 - `cpus` (number) - The number of cpus to use for building the VM.
   Defaults to `1`.
+
+- `disk_size` (number) - The size, in megabytes, of the hard disk to create
+  for the VM. By default, this is 40000 (about 40 GB).
 
 - `host_interfaces` (array of strings) - A list of which interfaces on the
   host should be searched for a IP address. The first IP address found on one

--- a/builder/parallels/ipsw/builder.go
+++ b/builder/parallels/ipsw/builder.go
@@ -191,6 +191,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		commonsteps.HTTPServerFromHTTPConfig(&b.config.HTTPConfig),
 		new(stepCreateVM),
+		new(stepCreateDisk),
 		&parallelscommon.StepPrlctl{
 			Commands: b.config.Prlctl,
 			Ctx:      b.config.ctx,

--- a/builder/parallels/ipsw/step_create_disk.go
+++ b/builder/parallels/ipsw/step_create_disk.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ipsw
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	parallelscommon "github.com/Parallels/packer-plugin-parallels/builder/parallels/common"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// This step creates the virtual disk that will be used as the
+// hard drive for the virtual machine.
+type stepCreateDisk struct{}
+
+func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*Config)
+	driver := state.Get("driver").(parallelscommon.Driver)
+	ui := state.Get("ui").(packersdk.Ui)
+	vmName := state.Get("vmName").(string)
+
+	command := []string{
+		"set", vmName,
+		"--device-add", "hdd",
+		"--type", "plain",
+		"--size", strconv.FormatUint(uint64(config.DiskSize), 10),
+		"--iface", "sata",
+	}
+
+	ui.Say("Creating hard drive...")
+	err := driver.Prlctl(command...)
+	if err != nil {
+		err := fmt.Errorf("Error creating hard drive: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepCreateDisk) Cleanup(state multistep.StateBag) {}

--- a/builder/parallels/ipsw/step_create_vm.go
+++ b/builder/parallels/ipsw/step_create_vm.go
@@ -37,6 +37,7 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 		"-o", "macos",
 		"--restore-image", ipswPath,
 		"--dst", config.OutputDir,
+		"--no-hdd",
 	}
 	commands[1] = []string{
 		"set", name,

--- a/docs/builders/ipsw.mdx
+++ b/docs/builders/ipsw.mdx
@@ -44,6 +44,7 @@ source "parallels-ipsw" "macvm_automated" {
   vm_name              = "macOS"
   cpus                 = "4"
   memory               = "8192"
+  disk_size            = "50000"
 }
 
 build {
@@ -173,6 +174,9 @@ In HCL2:
 
 - `cpus` (number) - The number of cpus to use for building the VM.
   Defaults to `1`.
+
+- `disk_size` (number) - The size, in megabytes, of the hard disk to create
+  for the VM. By default, this is 40000 (about 40 GB).
 
 - `host_interfaces` (array of strings) - A list of which interfaces on the
   host should be searched for a IP address. The first IP address found on one


### PR DESCRIPTION
Adds support for specifying `disk_size` when using the ipsw builder. 

Follows the same implementation as the iso builder, except that macOS on Apple Silicon only supports `disk_type`: `plain`, and `iface`: `sata`.  For that reason, I hard-coded those values in `step_create_disk.go`.

Closes #111 

