### PR TITLE
New ocr control features

### DIFF
--- a/.web-docs/components/builder/macvm/README.md
+++ b/.web-docs/components/builder/macvm/README.md
@@ -71,8 +71,9 @@ communicator is "ssh".
   A screen is considered matched if all the matching strings are present in the screen.
   The first matching screen will be considered & boot config of that screen will be used.
   If matching strings are empty, then it is considered as empty screen,
-  which will be considered when none of the other screens are matched (You can use this screen to -
-  make system wait for some time / execute a common boot command etc.).
+  empty screen has some special meaning, which will be considered when none of the other screens are matched.
+  You can use this screen to make system wait for some time / execute a common boot command etc.
+  The empty screen boot command will be executed repeatedly until a non-empty screen is found.
   If more than one empty screen is found, then it is considered as an error.
 
 - `ocr_library` (string) - OCR library to use. Two options are currently supported: "tesseract" and "vision".

--- a/builder/parallels/common/boot_screen_config.go
+++ b/builder/parallels/common/boot_screen_config.go
@@ -26,6 +26,9 @@ type BootScreenConfig struct {
 	// Specifies if the current screen is the last screen
 	// Screen based boot will stop after this screen
 	IsLastScreen bool `mapstructure:"is_last_screen"`
+	// If true, the screen will be deleted after first execution
+	// Default value is false
+	ExecuteOnlyOnce bool `mapstructure:"execute_only_once"`
 }
 
 func (c *BootScreenConfig) Prepare(ctx *interpolate.Context) (errs []error) {
@@ -35,6 +38,10 @@ func (c *BootScreenConfig) Prepare(ctx *interpolate.Context) (errs []error) {
 	if len(c.ScreenName) == 0 {
 		errs = append(errs,
 			fmt.Errorf("screen name should not be empty"))
+	}
+
+	if !c.ExecuteOnlyOnce {
+		c.ExecuteOnlyOnce = false
 	}
 
 	if len(errs) > 0 {

--- a/builder/parallels/common/boot_screen_config.hcl2spec.go
+++ b/builder/parallels/common/boot_screen_config.hcl2spec.go
@@ -16,6 +16,7 @@ type FlatBootScreenConfig struct {
 	ScreenName        *string  `mapstructure:"screen_name" cty:"screen_name" hcl:"screen_name"`
 	MatchingStrings   []string `mapstructure:"matching_strings" cty:"matching_strings" hcl:"matching_strings"`
 	IsLastScreen      *bool    `mapstructure:"is_last_screen" cty:"is_last_screen" hcl:"is_last_screen"`
+	ExecuteOnlyOnce   *bool    `mapstructure:"execute_only_once" cty:"execute_only_once" hcl:"execute_only_once"`
 }
 
 // FlatMapstructure returns a new FlatBootScreenConfig.
@@ -36,6 +37,7 @@ func (*FlatBootScreenConfig) HCL2Spec() map[string]hcldec.Spec {
 		"screen_name":            &hcldec.AttrSpec{Name: "screen_name", Type: cty.String, Required: false},
 		"matching_strings":       &hcldec.AttrSpec{Name: "matching_strings", Type: cty.List(cty.String), Required: false},
 		"is_last_screen":         &hcldec.AttrSpec{Name: "is_last_screen", Type: cty.Bool, Required: false},
+		"execute_only_once":      &hcldec.AttrSpec{Name: "execute_only_once", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/parallels/common/ocr_wrapper.go
+++ b/builder/parallels/common/ocr_wrapper.go
@@ -8,9 +8,11 @@ import "errors"
 type OCRWrapper interface {
 	// IdentifyCurrentScreen takes a screenshot of the current screen and returns the BootScreenConfig that matches the screen.
 	IdentifyCurrentScreen(imagePath string) (bootScreenConfig BootScreenConfig, err error)
+	// Removes the screen config with specified name if exist
+	RemoveBootScreenConfigIfExist(screenName string)
 }
 
-func NewOCRWrapper(OCRLibrary string, ScreenConfigs []BootScreenConfig) (OCRWrapper, error) {
+func NewOCRWrapper(OCRLibrary string, ScreenConfigs map[string]BootScreenConfig) (OCRWrapper, error) {
 	if OCRLibrary == "vision" {
 		return NewVisionOCRWrapper(ScreenConfigs), nil
 	} else if OCRLibrary == "tesseract" {

--- a/builder/parallels/common/step_screen_based_boot.go
+++ b/builder/parallels/common/step_screen_based_boot.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/packer-plugin-sdk/bootcommand"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -29,7 +30,7 @@ type StepScreenBasedBoot struct {
 func (s *StepScreenBasedBoot) executeBootCommand(bootConfig bootcommand.BootConfig, ctx context.Context, state multistep.StateBag) error {
 	// Execute the boot command
 	step := StepTypeBootCommand{
-		BootWait:       bootConfig.BootWait,
+		BootWait:       -1,
 		BootCommand:    bootConfig.FlatBootCommand(),
 		HostInterfaces: []string{},
 		VMName:         s.VmName,
@@ -50,6 +51,29 @@ func (s *StepScreenBasedBoot) executeBootCommand(bootConfig bootcommand.BootConf
 	return errors.New("boot command failed")
 }
 
+func (s *StepScreenBasedBoot) captureScreen(state multistep.StateBag, windowId string, fileName string) error {
+	driver := state.Get("driver").(Driver)
+	prlctlCurrVersionStr, verErr := driver.Version()
+	if verErr != nil {
+		return verErr
+	}
+	prlctlCurrVersion, _ := version.NewVersion(prlctlCurrVersionStr)
+	v2, _ := version.NewVersion("20.0.0")
+
+	if prlctlCurrVersion.LessThan(v2) {
+		// Path to the binary you want to execute
+		binaryPath := "/usr/sbin/screencapture"
+		// Window ID option
+		windowIDOption := "-l" + fmt.Sprint(windowId)
+		// Command-line arguments to pass to the binary
+		args := []string{"-x", windowIDOption, fileName}
+		_, err := executeBinary(binaryPath, args...)
+		return err
+	} else {
+		return driver.Prlctl("capture", s.VmName, "--file", fileName)
+	}
+}
+
 func (s *StepScreenBasedBoot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	// We don't have any screen configs, so no wasting of time here.
 	if (s.ScreenConfigs == nil) || (len(s.ScreenConfigs) == 0) {
@@ -65,21 +89,14 @@ func (s *StepScreenBasedBoot) Run(ctx context.Context, state multistep.StateBag)
 	}
 
 	ui := state.Get("ui").(packersdk.Ui)
-	// Window ID option
-	windowIDOption := "-l" + fmt.Sprint(windowId)
-	// Path to the binary you want to execute
-	binaryPath := "/usr/sbin/screencapture"
 	// Create a temporary file to store the screenshot
 	file, err := os.CreateTemp("", "screenshot*.png")
 	if err != nil {
 		log.Println("Error creating temporary file:", err)
 		return multistep.ActionHalt
 	}
-
 	file.Close()
 	defer os.Remove(file.Name())
-	// Command-line arguments to pass to the binary
-	args := []string{"-x", windowIDOption, file.Name()}
 
 	ui.Say("Starting screen based boot...")
 
@@ -102,7 +119,7 @@ func (s *StepScreenBasedBoot) Run(ctx context.Context, state multistep.StateBag)
 		prevTime = time.Now()
 
 		// Capturing the screenshot
-		_, err := executeBinary(binaryPath, args...)
+		err := s.captureScreen(state, fmt.Sprint(windowId), file.Name())
 		if err != nil {
 			log.Println("Error: '", err, "' while capturing the screenshot.")
 			ui.Error("Error capturing the screenshot. Make sure you have the necessary permissions.")

--- a/builder/parallels/common/tesseract_ocr_wrapper.go
+++ b/builder/parallels/common/tesseract_ocr_wrapper.go
@@ -11,10 +11,10 @@ import (
 )
 
 type TesseractOCRWrapper struct {
-	ScreenConfigs []BootScreenConfig
+	ScreenConfigs map[string]BootScreenConfig
 }
 
-func NewTesseractOCRWrapper(ScreenConfigs []BootScreenConfig) *TesseractOCRWrapper {
+func NewTesseractOCRWrapper(ScreenConfigs map[string]BootScreenConfig) *TesseractOCRWrapper {
 	tesseractOCRWrapper := TesseractOCRWrapper{
 		ScreenConfigs: ScreenConfigs,
 	}
@@ -89,4 +89,8 @@ func (c *TesseractOCRWrapper) IdentifyCurrentScreen(imagePath string) (bootScree
 
 	log.Println("Detected text: ", text)
 	return c.detectScreen(text), nil
+}
+
+func (c *TesseractOCRWrapper) RemoveBootScreenConfigIfExist(screenName string) {
+	delete(c.ScreenConfigs, screenName)
 }

--- a/builder/parallels/common/vision_ocr_wrapper.go
+++ b/builder/parallels/common/vision_ocr_wrapper.go
@@ -24,11 +24,11 @@ import (
 // VisionOCRWrapper is a struct that acts as an Adapter to Apple's Vision Framework for Optical Character Recognition.
 type VisionOCRWrapper struct {
 	referenceScalingFactor float32
-	ScreenConfigs          []BootScreenConfig
+	ScreenConfigs          map[string]BootScreenConfig
 	OCRImpl                *C.OCRImpl
 }
 
-func NewVisionOCRWrapper(ScreenConfigs []BootScreenConfig) *VisionOCRWrapper {
+func NewVisionOCRWrapper(ScreenConfigs map[string]BootScreenConfig) *VisionOCRWrapper {
 	ocrRunner := VisionOCRWrapper{
 		referenceScalingFactor: 0.0,
 		ScreenConfigs:          ScreenConfigs,
@@ -38,6 +38,8 @@ func NewVisionOCRWrapper(ScreenConfigs []BootScreenConfig) *VisionOCRWrapper {
 	for _, screenConfig := range ScreenConfigs {
 		bootScreenConfig := C.newBootScreenConfig()
 
+		// Add the screen name
+		C.setScreenName(bootScreenConfig, C.CString(screenConfig.ScreenName))
 		for _, matchingString := range screenConfig.MatchingStrings {
 			lowerCase := strings.ToLower(matchingString)
 			C.addMatchingString(bootScreenConfig, C.CString(lowerCase))
@@ -49,11 +51,13 @@ func NewVisionOCRWrapper(ScreenConfigs []BootScreenConfig) *VisionOCRWrapper {
 	return &ocrRunner
 }
 
-func (c *VisionOCRWrapper) detectScreenFromImageUsingVisionAPI(imagePath string, useRefScalingFactor bool, screenId chan<- int, err chan<- error) {
+func (c *VisionOCRWrapper) detectScreenFromImageUsingVisionAPI(imagePath string, useRefScalingFactor bool, screenName chan<- string, err chan<- error) {
 	errorBuffer := C.CString("")
 	defer C.free(unsafe.Pointer(errorBuffer))
 	textBuffer := C.CString("")
 	defer C.free(unsafe.Pointer(textBuffer))
+	detectedScreenName := C.CString("")
+	defer C.free(unsafe.Pointer(detectedScreenName))
 
 	refScalingFactor := C.double(0.0)
 	if useRefScalingFactor {
@@ -61,9 +65,11 @@ func (c *VisionOCRWrapper) detectScreenFromImageUsingVisionAPI(imagePath string,
 	}
 
 	bestScalingFactor := C.double(0.0)
-	result := C.detectScreenFromImage(c.OCRImpl, C.CString(imagePath), refScalingFactor, &textBuffer, &errorBuffer, &bestScalingFactor)
-	if result == -1 {
-		screenId <- -1
+
+	C.detectScreenFromImage(c.OCRImpl, C.CString(imagePath), refScalingFactor, &textBuffer, &errorBuffer, &bestScalingFactor, &detectedScreenName)
+	result := C.GoString(detectedScreenName)
+	if len(result) == 0 {
+		screenName <- ""
 		err <- errors.New(C.GoString(errorBuffer))
 		return
 	}
@@ -74,7 +80,7 @@ func (c *VisionOCRWrapper) detectScreenFromImageUsingVisionAPI(imagePath string,
 		log.Printf("Best detected text: %s", C.GoString(textBuffer))
 	}
 
-	screenId <- int(result)
+	screenName <- result
 	err <- nil
 }
 
@@ -87,18 +93,24 @@ func (c *VisionOCRWrapper) IdentifyCurrentScreen(imagePath string) (bootScreenCo
 
 	for {
 		// Use Vision Framework for OCR
-		chanScreenId := make(chan int)
+		chanScreenName := make(chan string)
 		chanErr := make(chan error)
-		go c.detectScreenFromImageUsingVisionAPI(imagePath, useRefScalingFactor, chanScreenId, chanErr)
-		screenId := <-chanScreenId
+		go c.detectScreenFromImageUsingVisionAPI(imagePath, useRefScalingFactor, chanScreenName, chanErr)
+		screenName := <-chanScreenName
 		err := <-chanErr
 
-		if err != nil || screenId == -1 {
-			fmt.Println("Error:", err)
+		fmt.Println("Detected screen name", screenName)
+		if err != nil || len(screenName) == 0 {
+			fmt.Println("Screen not detected (error if any:", err, ")")
 			return BootScreenConfig{}, err
 		}
 
-		screenConfig = c.ScreenConfigs[screenId]
+		exists := false
+		screenConfig, exists = c.ScreenConfigs[screenName]
+		if !exists {
+			return BootScreenConfig{}, errors.New("detected screen not found in the configuration, please report this bug")
+		}
+
 		// Did we detect an empty screen ? Try again without scaling factor to be sure
 		if useRefScalingFactor && (screenConfig.MatchingStrings == nil || len(screenConfig.MatchingStrings) == 0) {
 			useRefScalingFactor = false
@@ -107,5 +119,10 @@ func (c *VisionOCRWrapper) IdentifyCurrentScreen(imagePath string) (bootScreenCo
 		}
 	}
 
+	fmt.Println("Detected screen name 2", screenConfig.ScreenName)
 	return screenConfig, nil
+}
+
+func (c *VisionOCRWrapper) RemoveBootScreenConfigIfExist(screenName string) {
+	C.deleteBootScreenConfig(c.OCRImpl, C.CString(screenName))
 }

--- a/builder/parallels/macvm/builder.go
+++ b/builder/parallels/macvm/builder.go
@@ -52,6 +52,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("ui", ui)
 	state.Put("http_port", 0)
 
+	// Moving to a map for better processing
+	screenConfigsMap := make(map[string]parallelscommon.BootScreenConfig)
+	for _, screenConfig := range b.config.BootScreenConfig {
+		screenConfigsMap[screenConfig.ScreenName] = screenConfig
+	}
+
 	// Build the steps.
 	steps := []multistep.Step{
 		&parallelscommon.StepOutputDir{
@@ -78,7 +84,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			GroupInterval:  b.config.BootConfig.BootGroupInterval,
 		},
 		&parallelscommon.StepScreenBasedBoot{
-			ScreenConfigs: b.config.BootScreenConfig,
+			ScreenConfigs: screenConfigsMap,
 			OCRLibrary:    b.config.OCRLibrary,
 			VmName:        b.config.VMName,
 			Ctx:           b.config.ctx,

--- a/docs-partials/builder/parallels/common/BootScreenConfig-not-required.mdx
+++ b/docs-partials/builder/parallels/common/BootScreenConfig-not-required.mdx
@@ -7,4 +7,7 @@
 - `is_last_screen` (bool) - Specifies if the current screen is the last screen
   Screen based boot will stop after this screen
 
+- `execute_only_once` (bool) - If true, the screen will be deleted after first execution
+  Default value is false
+
 <!-- End of code generated from the comments of the BootScreenConfig struct in builder/parallels/common/boot_screen_config.go; -->

--- a/docs-partials/builder/parallels/ipsw/Config-not-required.mdx
+++ b/docs-partials/builder/parallels/ipsw/Config-not-required.mdx
@@ -4,8 +4,9 @@
   A screen is considered matched if all the matching strings are present in the screen.
   The first matching screen will be considered & boot config of that screen will be used.
   If matching strings are empty, then it is considered as empty screen,
-  which will be considered when none of the other screens are matched (You can use this screen to -
-  make system wait for some time / execute a common boot command etc.).
+  empty screen has some special meaning, which will be considered when none of the other screens are matched.
+  You can use this screen to make system wait for some time / execute a common boot command etc.
+  The empty screen boot command will be executed repeatedly until a non-empty screen is found.
   If more than one empty screen is found, then it is considered as an error.
 
 - `ocr_library` (string) - OCR library to use. Two options are currently supported: "tesseract" and "vision".

--- a/docs-partials/builder/parallels/macvm/Config-not-required.mdx
+++ b/docs-partials/builder/parallels/macvm/Config-not-required.mdx
@@ -4,8 +4,9 @@
   A screen is considered matched if all the matching strings are present in the screen.
   The first matching screen will be considered & boot config of that screen will be used.
   If matching strings are empty, then it is considered as empty screen,
-  which will be considered when none of the other screens are matched (You can use this screen to -
-  make system wait for some time / execute a common boot command etc.).
+  empty screen has some special meaning, which will be considered when none of the other screens are matched.
+  You can use this screen to make system wait for some time / execute a common boot command etc.
+  The empty screen boot command will be executed repeatedly until a non-empty screen is found.
   If more than one empty screen is found, then it is considered as an error.
 
 - `ocr_library` (string) - OCR library to use. Two options are currently supported: "tesseract" and "vision".


### PR DESCRIPTION
With this new change, following are supported : 

1. New 'execute_only_once' tag for all screens, this will allow users to write sequences to avoid some screens after execution, like desktop. 
2. Repeated empty screen execution, if no screen is matching, empty screen will execute continuously. This will allow users to properly skip screens with no-text (initial screens, loading screens) etc.
3. Now we use 'prlctl capture' for capturing screenshots, permissions to terminal is no longer required!