### PR TITLE
Fix crash when empty screen is not present

### DIFF
--- a/builder/parallels/common/vision_ocr.mm
+++ b/builder/parallels/common/vision_ocr.mm
@@ -238,7 +238,9 @@
 		if (topConfidenceScaleFactor)
 			*topConfidenceScaleFactor = topConfidenceScalingFactor;
 		*textBuffer = strdup(bestRecognizedText.UTF8String);
-		*detectedScreenName = strdup(screenConfigs[result].screenName.UTF8String);
+
+		if (result != -1)
+			*detectedScreenName = strdup(screenConfigs[result].screenName.UTF8String);
 	}
 }
 


### PR DESCRIPTION
Crash happens when empty screen is not present and detection mechanism fails to detect a screen. I've also added mechanism to repeat detection in case of previous scaling factor fails.

Fixes #123 