### PR TITLE
Remove net0 from boot-order settings to be compatible with Parallels 20.2

### DIFF
--- a/builder/parallels/iso/step_set_boot_order.go
+++ b/builder/parallels/iso/step_set_boot_order.go
@@ -32,7 +32,7 @@ func (s *stepSetBootOrder) Run(ctx context.Context, state multistep.StateBag) mu
 	ui.Say("Setting the boot order...")
 	command := []string{
 		"set", vmName,
-		"--device-bootorder", "hdd0 cdrom0 net0",
+		"--device-bootorder", "hdd0 cdrom0",
 	}
 
 	if err := driver.Prlctl(command...); err != nil {


### PR DESCRIPTION
It looks like Parallels 20.2 removed the "net0" as a boot device, therefore settings this fails.
Removing this from the boot order command makes packer succeed again.

Closes #128

